### PR TITLE
change gsed to sed & fixing several issues

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,61 +1,64 @@
-#!/bin/bash
-set -ex
+#!/usr/bin/env bash
+# - The -e option causes the shell to exit immediately if any command exits with a non-zero status.
+# - The -o pipefail option causes a pipeline to fail if any command in the pipeline fails, rather than just the last command.
+# - The -x option enables verbose mode, which causes the shell to print each command before executing it.
+set -eox pipefail
 
 echo "---- CONFIG ----"
-# get current app infos
-if [ -n "$config_file_path" ]; then
-    echo "get config from the config file"
-    source $config_file_path
+
+# Get current app information from config file or Bitrise inputs
+if [ -n "${config_file_path:-}" ]; then
+    echo "Getting config from the config file"
+    source "$config_file_path"
 else
-    echo "get config from bitrise input"
+    echo "Getting config from Bitrise inputs"
 fi
 
-if [[ ${check_android} == "yes" && ${android_permission_count} == "" ]]; then
-    echo "Error: Config keys are not set preperly"
-    echo "Error: You configured to check android part but android_permission_count is not set "
+# Check if config keys are set properly for Android and iOS
+if [[ "${check_android:-}" == "yes" && -z "${android_permission_count:-}" ]]; then
+    echo "Error: Config keys are not set properly"
+    echo "Error: You configured to check the Android part, but android_permission_count is not set"
     exit 1
 fi
 
-if [[ ${check_ios} == "yes" && ${ios_permission_count} == "" ]]; then
-    echo "Error: Config keys are not set preperly"
-    echo "Error: You configured to check ios part but ios_permission_count is not set "
+if [[ "${check_ios:-}" == "yes" && -z "${ios_permission_count:-}" ]]; then
+    echo "Error: Config keys are not set properly"
+    echo "Error: You configured to check the iOS part, but ios_permission_count is not set"
     exit 1
 fi
 
-if [[ ${check_android} == "yes" ]]; then
+if [[ "${check_android:-}" == "yes" ]]; then
     if [ ! -d "apk_decompiled" ]; then
-        echo "ERROR: Cannot find any decompiled apk"
+        echo "ERROR: Cannot find any decompiled APK"
         exit 1
     fi
 
-    # PERMISSION CHECK - count permissions which are into current build's manifest
-    CURRENT_ANDROID_PERMISSION_COUNT=$(echo $(grep -o -i "<uses-permission" apk_decompiled/AndroidManifest.xml | wc -l))
-    
-    envman add --key CURRENT_ANDROID_PERMISSION_COUNT --value $CURRENT_ANDROID_PERMISSION_COUNT
-    grep "<uses-permission" apk_decompiled/AndroidManifest.xml > list_android_permissions.txt
-    gsed -ri 's/<uses-permission android:name="//g' list_android_permissions.txt
-    gsed -ri 's/"\/>//g' list_android_permissions.txt
-    cp list_android_permissions.txt $BITRISE_DEPLOY_DIR/list_android_permissions.txt
+    # Count permissions that are in the current build's manifest
+    CURRENT_ANDROID_PERMISSION_COUNT=$(grep -o -i "<uses-permission" apk_decompiled/AndroidManifest.xml | wc -l)
+    envman add --key "CURRENT_ANDROID_PERMISSION_COUNT" --value "$CURRENT_ANDROID_PERMISSION_COUNT"
+
+    grep "<uses-permission" apk_decompiled/AndroidManifest.xml | sed -e 's/<uses-permission android:name="//g' -e 's/"\/>//g' > list_android_permissions.txt
+
+    cp list_android_permissions.txt "$BITRISE_DEPLOY_DIR/list_android_permissions.txt"
 fi
 
-if [[ ${check_ios} == "yes" ]]; then
-    if [[ ${ios_app_name} == "" ]]; then
-        echo "ERROR: Didn't find any ios app name ios_app_name: $ios_app_name"
+if [[ "${check_ios:-}" == "yes" ]]; then
+    if [[ -z "${ios_app_name:-}" ]]; then
+        echo "ERROR: Didn't find any iOS app name ios_app_name: $ios_app_name"
         exit 1
     fi
+
     if [ ! -d "ipa_unzipped" ]; then
-        echo "ERROR: Cannot find any decompiled apk"
+        echo "ERROR: Cannot find any unzipped IPA"
         exit 1
     fi
 
-    # PERMISSION CHECK - count permissions which are into current info.plist
-    CURRENT_IOS_PERMISSION_COUNT=$(echo $(grep -o -i "UsageDescription</key>" ipa_unzipped/Payload/$ios_app_name.app/Info.plist | wc -l))
+    # Count permissions that are in the current build's Info.plist
+    CURRENT_IOS_PERMISSION_COUNT=$(grep -o -i "UsageDescription</key>" ipa_unzipped/Payload/"$ios_app_name".app/Info.plist | wc -l)
+    envman add --key "CURRENT_IOS_PERMISSION_COUNT" --value "$CURRENT_IOS_PERMISSION_COUNT"
 
-    envman add --key CURRENT_IOS_PERMISSION_COUNT --value $CURRENT_IOS_PERMISSION_COUNT
-    grep "UsageDescription</key>" "ipa_unzipped/Payload/$ios_app_name.app/Info.plist" > list_ios_permissions.txt
-    gsed -ri 's/<key>//g' list_ios_permissions.txt
-    gsed -ri 's/<\/key>//g' list_ios_permissions.txt
-    cp list_ios_permissions.txt $BITRISE_DEPLOY_DIR/list_ios_permissions.txt
+    grep "UsageDescription</key>" "ipa_unzipped/Payload/$ios_app_name.app/Info.plist" | sed -e 's/<key>//g' -e 's/<\/key>//g' > list_ios_permissions.txt
+    cp list_ios_permissions.txt "$BITRISE_DEPLOY_DIR/list_ios_permissions.txt"
 fi
 
 echo "---- REPORT ----"
@@ -69,7 +72,7 @@ printf ">>>>>>>>>>  CURRENT APP PERMISSIONS  <<<<<<<<<<\n" >> quality_report.txt
 if [[ ${check_android} == "yes" ]]; then
     printf "Android permission count (from config): $android_permission_count \n" >> quality_report.txt
 fi
-if [[ ${check_android} == "yes" ]]; then
+if [[ ${check_ios} == "yes" ]]; then
     printf "iOS permission count (from config): $ios_permission_count \n" >> quality_report.txt
 fi
 
@@ -81,7 +84,7 @@ if [[ ${check_android} == "yes" ]]; then
         printf "!!! New Android permissions have been added !!!\n" >> quality_report.txt
         printf "You had: $android_permission_count permissions \n" >> quality_report.txt
         printf "And now: $CURRENT_ANDROID_PERMISSION_COUNT permissions \n" >> quality_report.txt
-        printf "You can see list of permissions into list_android_permissions.txt \n\n" >> quality_report.txt
+        printf "You can see the list of permissions into list_android_permissions.txt \n\n" >> quality_report.txt
     else
         printf "0 alert \n" >> quality_report.txt
     fi
@@ -94,7 +97,7 @@ if [[ ${check_ios} == "yes" ]]; then
         printf "!!! New iOS permissions have been added !!!\n" >> quality_report.txt
         printf "You had: $ios_permission_count permissions \n" >> quality_report.txt
         printf "And now: $CURRENT_IOS_PERMISSION_COUNT permissions \n" >> quality_report.txt
-        printf "You can see list of permissions into list_ios_permissions.txt \n\n" >> quality_report.txt
+        printf "You can see the list of permissions into list_ios_permissions.txt \n\n" >> quality_report.txt
     else
         printf "0 alert \n" >> quality_report.txt
     fi
@@ -103,12 +106,9 @@ fi
 
 cp quality_report.txt $BITRISE_DEPLOY_DIR/quality_report.txt || true
 
-if [ $CURRENT_ANDROID_PERMISSION_COUNT -gt $android_permission_count ]; then
+if [ $CURRENT_ANDROID_PERMISSION_COUNT -gt $android_permission_count ] || [ $CURRENT_IOS_PERMISSION_COUNT -gt $ios_permission_count ]; then
     echo "ERROR: New permissions have been added"
     exit 1
 fi
-if [ $CURRENT_IOS_PERMISSION_COUNT -gt $ios_permission_count ]; then
-    echo "ERROR: New permissions have been added"
-    exit 1
-fi
+
 exit 0


### PR DESCRIPTION
In the current version of Bitrise, this step can no longer be used in a workflow out of the box. Bitrise does not recognize the gsed (gnu-sed) command as a command, resulting in errors. Therefore gsed was replaced with sed and in the course of this the script was also simplified and small errors were corrected. Among other things, when describing the quality_report.txt, 'check_android' was checked twice instead of 'check_iOS' once.

Thanks! 